### PR TITLE
Update ecs.tf

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -62,7 +62,7 @@ resource "aws_ecs_task_definition" "taskdef" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.logs.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.id
           awslogs-stream-prefix = "n8n"
         }
       }


### PR DESCRIPTION
fix: replace deprecated aws_region.current.name with current.id

Replaced deprecated `name` attribute with `id` for AWS region data  source in ECS task definition CloudWatch logs configuration.

The `name` attribute is deprecated and will be removed in AWS provider v7.0.0.

Otherwise, terraform apply throws a warning:

│ Warning: Deprecated attribute
│ 
│   on .terraform/modules/n8n/ecs.tf line 65, in resource 
  "aws_ecs_task_definition" "taskdef":
│   65:           awslogs-region        = 
  data.aws_region.current.name
│ 
│ The attribute "name" is deprecated. Refer to the provider 

See: https://github.com/hashicorp/terraform-provider-aws/issues/42468